### PR TITLE
fix(nix): Make verus-lib more nix friendly

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -8,6 +8,8 @@ pkgs.mkShell {
     pkgs.z3_4_12
   ];
   shellHook = ''
+    z3_path=$(which z3)
+    export VERUS_Z3_PATH="$z3_path"
     export PATH="$PATH:${builtins.toString ./.}/source/target-verus/debug:${builtins.toString ./.}/source/target-verus/release:${pkgs.z3_4_12}/bin"
   '';
 }

--- a/source/rust_verify/src/consts.rs
+++ b/source/rust_verify/src/consts.rs
@@ -1,0 +1,2 @@
+pub const EXPECTED_Z3_VERSION: &str = "4.12.5";
+pub const EXPECTED_CVC5_VERSION: &str = "1.1.2";

--- a/source/rust_verify/src/lib.rs
+++ b/source/rust_verify/src/lib.rs
@@ -33,7 +33,6 @@ pub mod buckets;
 pub mod commands;
 pub mod config;
 
-#[path = "../../../tools/common/consts.rs"]
 pub mod consts;
 
 pub mod context;


### PR DESCRIPTION
Removed relative path which blocks this repo being nixifiable. This solution is not preferable. We should rather use a purely nix way (sed + copy consts.rs file).